### PR TITLE
feat(UR-50): 자녀정보 기반 History 조회 로직 개발

### DIFF
--- a/src/main/java/com/uplus/ggumi/config/exception/ErrorCode.java
+++ b/src/main/java/com/uplus/ggumi/config/exception/ErrorCode.java
@@ -28,8 +28,9 @@ public enum ErrorCode {
 	PARENT_NOT_EXIST(500, "부모 정보 찾기를 실패하였습니다", 1200),
 	CHILD_NOT_EXIST(500, "자녀 정보 찾기를 실패하를습니다.", 1201),
 	CHILDREN_NOT_EXIST(500, "자녀 리스트가 없습니다.", 1202 ),
-	CHILD_CREATION_LIMIT_REACHED(500, "더 이상 자녀를 생성할 수 없습니다", 1203 );
+	CHILD_CREATION_LIMIT_REACHED(500, "더 이상 자녀를 생성할 수 없습니다", 1203 ),
 
+	HISTORY_NOT_EXIST(500, "조건에 맞는 history 정보가 없습니다.", 1301);
 
 
 	private final int status;

--- a/src/main/java/com/uplus/ggumi/controller/HistoryController.java
+++ b/src/main/java/com/uplus/ggumi/controller/HistoryController.java
@@ -1,0 +1,41 @@
+package com.uplus.ggumi.controller;
+
+import com.uplus.ggumi.config.response.ResponseDto;
+import com.uplus.ggumi.config.response.ResponseUtil;
+import com.uplus.ggumi.dto.history.MbtiHistoryPageDto;
+import com.uplus.ggumi.service.HistoryService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/histories")
+public class HistoryController {
+
+    private final HistoryService historyService;
+
+    @GetMapping("")
+    public ResponseDto<MbtiHistoryPageDto> getHistory(HttpServletRequest request) {
+        String childId = getCookieValue(request, "ChildId");
+        return ResponseUtil.SUCCESS("자녀의 MBTI history 정보를 가져오는 것을 성공하였습니다.", historyService.getChildInfoMbtiHistory(childId));
+    }
+
+    private String getCookieValue(HttpServletRequest request, String cookieName) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(cookieName)) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/uplus/ggumi/dto/history/HistoryDtoForHistoryPage.java
+++ b/src/main/java/com/uplus/ggumi/dto/history/HistoryDtoForHistoryPage.java
@@ -1,0 +1,22 @@
+package com.uplus.ggumi.dto.history;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HistoryDtoForHistoryPage {
+
+    private double EI;
+    private double SN;
+    private double FT;
+    private double PJ;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/uplus/ggumi/dto/history/MbtiHistoryPageDto.java
+++ b/src/main/java/com/uplus/ggumi/dto/history/MbtiHistoryPageDto.java
@@ -1,0 +1,22 @@
+package com.uplus.ggumi.dto.history;
+
+import com.uplus.ggumi.domain.history.History;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MbtiHistoryPageDto {
+
+    private String name;
+    private int profileCode;
+
+    private List<HistoryDtoForHistoryPage> histories;
+}

--- a/src/main/java/com/uplus/ggumi/repository/HistoryRepository.java
+++ b/src/main/java/com/uplus/ggumi/repository/HistoryRepository.java
@@ -12,4 +12,11 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
     @Query("SELECT h FROM History h WHERE h.child.id = :childId ORDER BY h.createdAt DESC LIMIT 1")
     History findTopByChildIdOrderByCreatedAtDesc(@Param("childId") Long childId);
 
-}
+
+    @Query("SELECT h FROM History h " +
+            "WHERE h.child.id = :childId " +
+            "AND h.isDeleted = false " +
+            "GROUP BY FUNCTION('YEAR', h.createdAt), FUNCTION('WEEK', h.createdAt) " +
+            "HAVING h.createdAt = MAX(h.createdAt) " +
+            "ORDER BY h.createdAt DESC")
+    List<History> findByChildIdLatestHistoryByWeek(@Param("childId") Long childId);}

--- a/src/main/java/com/uplus/ggumi/service/HistoryService.java
+++ b/src/main/java/com/uplus/ggumi/service/HistoryService.java
@@ -1,0 +1,52 @@
+package com.uplus.ggumi.service;
+
+import com.uplus.ggumi.config.exception.ApiException;
+import com.uplus.ggumi.config.exception.ErrorCode;
+import com.uplus.ggumi.domain.child.Child;
+import com.uplus.ggumi.domain.history.History;
+import com.uplus.ggumi.dto.history.HistoryDtoForHistoryPage;
+import com.uplus.ggumi.dto.history.MbtiHistoryPageDto;
+import com.uplus.ggumi.repository.ChildRepository;
+import com.uplus.ggumi.repository.HistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryService {
+
+    private final HistoryRepository historyRepository;
+    private final ChildRepository childRepository;
+
+    public MbtiHistoryPageDto getChildInfoMbtiHistory(String childId) {
+        Long cId = Long.valueOf(childId);
+
+        Child child = childRepository.findById(cId)
+                .orElseThrow(() -> new ApiException(ErrorCode.CHILD_NOT_EXIST));
+        List<History> histories = historyRepository.findByChildIdLatestHistoryByWeek(cId);
+        if(histories.isEmpty()) {
+            throw new ApiException(ErrorCode.HISTORY_NOT_EXIST);
+        }
+
+        // History -> HistoryDtoForHistoryPage로 변환
+        List<HistoryDtoForHistoryPage> historyDtos = histories.stream()
+                .map(history -> HistoryDtoForHistoryPage.builder()
+                        .EI(history.getEI())
+                        .SN(history.getSN())
+                        .FT(history.getFT())
+                        .PJ(history.getPJ())
+                        .createdAt(history.getCreatedAt()) // 생성 시간
+                        .build()
+                )
+                .toList();
+
+        return MbtiHistoryPageDto.builder()
+                .name(child.getName())
+                .profileCode(child.getProfileCode())
+                .histories(historyDtos)
+                .build();
+    }
+}


### PR DESCRIPTION
## 관련 링크
[UR-50](https://ureca.atlassian.net/browse/UR-50)

## 작업 내용
히스토리 조회 api 구현

히스토리 페이지로 전환되면서 해당 api 조회 시
- 쿠키에 저장된 자녀 정보를 통해 해당 자녀의 히스토리 조회
- 조회되는 히스토리는 매주 1개의 변화 로그이며 최신순 정렬이 되어서 전달되도록 함.
- 조회 결과가 없을 경우는 ErrorCode.HISTORY_NOT_EXIST 전달.

## 논의 사항
자녀 정보를 브라우저가 유지하도록 해야 flow 구현이 가능할 것 같습니다.
쿠키, 세션 스토리지 어떤 것이 저희 목적에 맞을지 논의가 필요할 것 같습니다.
현재는 일단 쿠키로 로직 구현한 상태입니다.

추가로 쿠키 세팅은 백엔드의 영역인지 프론트 영역인지 공부하고 오겠습니다...