### PR TITLE
feat(UR-71): 도서 총 좋아요 개수 증감 로직 개발 및 자녀 성향 변화에 따른 추천 도서 업데이트 로직 개발

### DIFF
--- a/src/main/java/com/uplus/ggumi/GgumiApplication.java
+++ b/src/main/java/com/uplus/ggumi/GgumiApplication.java
@@ -2,7 +2,9 @@ package com.uplus.ggumi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class GgumiApplication {
 

--- a/src/main/java/com/uplus/ggumi/controller/BookDetailController.java
+++ b/src/main/java/com/uplus/ggumi/controller/BookDetailController.java
@@ -45,8 +45,6 @@ public class BookDetailController {
         return ResponseUtil.SUCCESS("싫어요를 취소했습니다.", bookDetailService.undoHate(bookId, request.get("childId")));
     }
 
-
-
     @PostMapping("/{bookId}/calculation-like")
     public ResponseDto<Long> calculationWhenClickLike(@PathVariable Long bookId, @RequestBody Map<String, Long> request) {
         return ResponseUtil.SUCCESS("책의 점수를 기반으로 점수를 계산합니다.", bookDetailService.calculateChildScoreWithBookScoreWhenClickLike(bookId, request.get("childId")));

--- a/src/main/java/com/uplus/ggumi/controller/BookDetailController.java
+++ b/src/main/java/com/uplus/ggumi/controller/BookDetailController.java
@@ -35,10 +35,17 @@ public class BookDetailController {
         return ResponseUtil.SUCCESS("싫어요를 눌렀습니다.", bookDetailService.setHate(bookId, request.get("childId")));
     }
 
-    @PostMapping("/{bookId}/undo")
-    public ResponseDto<Long> undoFeedback(@PathVariable Long bookId, @RequestBody Map<String, Long> request) {
-        return ResponseUtil.SUCCESS("피드백을 취소했습니다.", bookDetailService.undoFeedback(bookId, request.get("childId")));
+    @PostMapping("/{bookId}/undo-like")
+    public ResponseDto<Long> undoLike(@PathVariable Long bookId, @RequestBody Map<String, Long> request) {
+        return ResponseUtil.SUCCESS("좋아요를 취소했습니다.", bookDetailService.undoLike(bookId, request.get("childId")));
     }
+
+    @PostMapping("/{bookId}/undo-hate")
+    public ResponseDto<Long> undoHate(@PathVariable Long bookId, @RequestBody Map<String, Long> request) {
+        return ResponseUtil.SUCCESS("싫어요를 취소했습니다.", bookDetailService.undoHate(bookId, request.get("childId")));
+    }
+
+
 
     @PostMapping("/{bookId}/calculation-like")
     public ResponseDto<Long> calculationWhenClickLike(@PathVariable Long bookId, @RequestBody Map<String, Long> request) {

--- a/src/main/java/com/uplus/ggumi/dto/bookDetail/BookDetailResponseDto.java
+++ b/src/main/java/com/uplus/ggumi/dto/bookDetail/BookDetailResponseDto.java
@@ -20,6 +20,7 @@ public class BookDetailResponseDto {
     private String bookImage;
     private String content;
     private LocalDateTime createdAt;
+    private int likes;
     private Thumbs feedback;
 
 }

--- a/src/main/java/com/uplus/ggumi/repository/BookDetailRepository.java
+++ b/src/main/java/com/uplus/ggumi/repository/BookDetailRepository.java
@@ -9,6 +9,4 @@ public interface BookDetailRepository {
 
     Long setHate(Long key, Long value);
 
-    Long undoFeedback(Long key, Long value);
-
 }

--- a/src/main/java/com/uplus/ggumi/repository/BookRepository.java
+++ b/src/main/java/com/uplus/ggumi/repository/BookRepository.java
@@ -1,11 +1,19 @@
 package com.uplus.ggumi.repository;
 
 import com.uplus.ggumi.domain.book.Book;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
 
     Book findBookById(Long bookId);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Book b SET b.likes = :likes WHERE b.id = :bookId")
+    void updateLikes(Long bookId, int likes);
 }

--- a/src/main/java/com/uplus/ggumi/repository/FeedbackRepository.java
+++ b/src/main/java/com/uplus/ggumi/repository/FeedbackRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 @Repository
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
-    Optional<Feedback> findByChildId(Long childId);
+    Optional<Feedback> findByBookIdAndChildId(Long bookId, Long childId);
 
 }

--- a/src/main/java/com/uplus/ggumi/repository/RecommendRepository.java
+++ b/src/main/java/com/uplus/ggumi/repository/RecommendRepository.java
@@ -1,0 +1,9 @@
+package com.uplus.ggumi.repository;
+
+import com.uplus.ggumi.domain.recommend.Recommend;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecommendRepository extends JpaRepository<Recommend, Long> {
+}

--- a/src/main/java/com/uplus/ggumi/service/BookDetailService.java
+++ b/src/main/java/com/uplus/ggumi/service/BookDetailService.java
@@ -7,6 +7,7 @@ import com.uplus.ggumi.domain.child.Child;
 import com.uplus.ggumi.domain.feedback.Feedback;
 import com.uplus.ggumi.domain.feedback.Thumbs;
 import com.uplus.ggumi.domain.history.History;
+import com.uplus.ggumi.domain.recommend.Recommend;
 import com.uplus.ggumi.dto.bookDetail.BookDetailResponseDto;
 import com.uplus.ggumi.repository.*;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @Slf4j
@@ -21,9 +25,15 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class BookDetailService implements BookDetailRepository {
 
+    /* 추천 도서 지정 개수 */
+    public static final int RECOMMEND_BOOK_COUNT = 8;
+    /* 총 좋아요 개수 Key 값 */
     private static final String TOTAL_LIKES = "totalLikes:";
+    /* 좋아요 Key 값 */
     private static final String LIKE = "like:";
+    /* 싫어요 Key 값 */
     private static final String HATE = "hate:";
+    /* 학습률 */
     private static final Double LEARNING_RATE = 0.15;
 
     private final RedisTemplate<String, Object> redisTemplate;
@@ -32,6 +42,7 @@ public class BookDetailService implements BookDetailRepository {
     private final HistoryRepository historyRepository;
     private final ChildRepository childRepository;
     private final FeedbackRepository feedbackRepository;
+    private final RecommendRepository recommendRepository;
 
     /* 도서 상세 페이지 내용을 보내기 위함 */
     public BookDetailResponseDto getBookDetail(Long bookId, Long childId) {
@@ -39,7 +50,7 @@ public class BookDetailService implements BookDetailRepository {
         Child child = childRepository.findById(childId).orElseThrow(() -> new ApiException(ErrorCode.CHILD_NOT_EXIST));
 
         /* 자녀가 해당 도서를 처음 방문했을 경우 새로운 피드백을 생성해준다. */
-        Feedback feedback = feedbackRepository.findByChildId(childId).orElseGet(() -> {
+        Feedback feedback = feedbackRepository.findByBookIdAndChildId(bookId, childId).orElseGet(() -> {
             Feedback newFeedback = Feedback.builder()
                     .child(child)
                     .book(book)
@@ -131,8 +142,14 @@ public class BookDetailService implements BookDetailRepository {
         History newHistory = new History(newChildEIScore, newChildSNScore, newChildFTScore, newChildPJScore, history.getChild());
 
         historyRepository.save(newHistory);
+        updateRecommendBooks(newHistory);
 
         return newHistory.getId();
+    }
+
+    /* 싫어요, 미선택 -> 좋아요를 눌렀을 때의 알고리즘 */
+    private double getNewChildScoreWhenClickLike(double child, double book) {
+        return Math.max(0, Math.min(1, child + (LEARNING_RATE * (book - child))));
     }
 
     /* 좋아요 -> 싫어요, 미선택을 눌렀던 시점의 점수 계산 및 기록 저장 */
@@ -152,13 +169,9 @@ public class BookDetailService implements BookDetailRepository {
         History newHistory = new History(newChildEIScore, newChildSNScore, newChildFTScore, newChildPJScore, history.getChild());
 
         historyRepository.save(newHistory);
+        updateRecommendBooks(newHistory);
 
         return newHistory.getId();
-    }
-
-    /* 싫어요, 미선택 -> 좋아요를 눌렀을 때의 알고리즘 */
-    private double getNewChildScoreWhenClickLike(double child, double book) {
-        return Math.max(0, Math.min(1, child + (LEARNING_RATE * (book - child))));
     }
 
     /* 좋아요 -> 싫어요, 미선택을 눌렀을 때의 알고리즘 */
@@ -166,5 +179,36 @@ public class BookDetailService implements BookDetailRepository {
         return Math.max(0, Math.min(1, child + (LEARNING_RATE * (child - book))));
     }
 
+    /* 자녀 성향 점수가 변하는 시점에 추천 도서 목록을 업데이트 하는 메서드 */
+    private void updateRecommendBooks(History history) {
+        List<Book> books = bookRepository.findAll();
 
+        Map<Book, Double> map = new HashMap<>();
+        for (Book book : books) {
+            map.put(book, Math.abs(history.getEI() - book.getEI()) + Math.abs(history.getSN() - book.getSN()) + Math.abs(history.getPJ() - book.getPJ()) + Math.abs(history.getFT() - book.getFT()));
+        }
+
+        /* Stream API를 사용해 값(Value) 기준으로 오름차순 정렬한 후 Key 값만 리스트로 수집 */
+        List<Book> sortedKeys = map.entrySet()
+                .stream()
+                .sorted(Map.Entry.comparingByValue())  // Value 기준으로 정렬
+                .map(Map.Entry::getKey)                // Key 값만 추출
+                .toList();                             // 리스트로 수집
+
+        /* 새롭게 업데이트 한 책들을 넣기 전에 해당 테이블의 책들을 비워준다. */
+        recommendRepository.deleteAll();
+
+        /* 상위 RECOMMEND_BOOK_COUNT 권의 책만 추천 테이블에 넣어준다. */
+        int count = 0;
+        for (Book recommendBook : sortedKeys) {
+            if (count == RECOMMEND_BOOK_COUNT) {
+                return;
+            }
+            recommendRepository.save(Recommend.builder()
+                    .book(recommendBook)
+                    .child(history.getChild())
+                    .build());
+            count++;
+        }
+    }
 }

--- a/src/main/java/com/uplus/ggumi/service/BookDetailService.java
+++ b/src/main/java/com/uplus/ggumi/service/BookDetailService.java
@@ -14,16 +14,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class BookDetailService implements BookDetailRepository {
 
+    public static final int TTL = 1;
+    private static final String TOTAL_LIKES = "totalLikes:";
     private static final String LIKE = "like:";
     private static final String HATE = "hate:";
-
     private static final Double LEARNING_RATE = 0.15;
-
     private final RedisTemplate<String, Object> redisTemplate;
 
     private final BookRepository bookRepository;
@@ -53,6 +56,7 @@ public class BookDetailService implements BookDetailRepository {
             redisTemplate.opsForSet().add(HATE + bookId, childId.toString());
         }
 
+        /* 도서 상세 페이지에 필요한 데이터 */
         return BookDetailResponseDto.builder()
                 .title(book.getTitle())
                 .author(book.getAuthor())
@@ -60,15 +64,29 @@ public class BookDetailService implements BookDetailRepository {
                 .bookImage(book.getBook_image())
                 .createdAt(book.getCreatedAt())
                 .publisher(book.getPublisher())
+                .likes(getTotalLikes(book, bookId))
                 .feedback(feedback.getThumbs())
                 .build();
+    }
+
+    /* 해당 도서의 총 좋아요 수에 대한 Cache Aside 작업 */
+    private Integer getTotalLikes(Book book, Long bookId) {
+        Object cachedLikes = redisTemplate.opsForValue().get(TOTAL_LIKES + bookId);
+        if (cachedLikes != null) {
+            return Integer.parseInt(cachedLikes.toString());
+        }
+
+        redisTemplate.opsForValue().set(TOTAL_LIKES + bookId, String.valueOf(book.getLikes()), TTL, TimeUnit.HOURS);
+
+        return book.getLikes();
     }
 
     @Override
     public Long setLike(Long key, Long value) {
         /* 싫어요에 대한 기록을 지워줌 */
         redisTemplate.opsForSet().remove(HATE + key.toString(), value.toString());
-
+        /* 총 좋아요 개수 +1 */
+        redisTemplate.opsForValue().increment(TOTAL_LIKES + key);
         return redisTemplate.opsForSet().add(LIKE + key, value.toString());
     }
 
@@ -76,15 +94,25 @@ public class BookDetailService implements BookDetailRepository {
     public Long setHate(Long key, Long value) {
         /* 좋아요에 대한 기록을 지워줌 */
         redisTemplate.opsForSet().remove(LIKE + key.toString(), value.toString());
-
+        /* 총 좋아요 개수 -1, 단 좋아요의 개수가 0 미만으로 가면 안됨. */
+        if (Integer.parseInt(Objects.requireNonNull(redisTemplate.opsForValue().get(TOTAL_LIKES + key)).toString()) > 0) {
+            redisTemplate.opsForValue().decrement(TOTAL_LIKES + key);
+        }
         return redisTemplate.opsForSet().add(HATE + key, value.toString());
     }
 
-    @Override
-    public Long undoFeedback(Long key, Long value) {
-        /* 좋아요,싫어요 모든 정보를 지워줌 */
-        redisTemplate.opsForSet().remove(HATE + key.toString(), value.toString());
-        return redisTemplate.opsForSet().remove(LIKE + key, value.toString());
+    public Long undoLike(Long key, Long value) {
+        /* 총 좋아요 개수 -1, 단 좋아요의 개수가 0 미만으로 가면 안됨. */
+        if (Integer.parseInt(Objects.requireNonNull(redisTemplate.opsForValue().get(TOTAL_LIKES + key)).toString()) > 0) {
+            redisTemplate.opsForValue().decrement(TOTAL_LIKES + key);
+        }
+        /* 좋아요 정보를 지워줌 */
+        return redisTemplate.opsForSet().remove(LIKE + key.toString(), value.toString());
+    }
+
+    public Long undoHate(Long key, Long value) {
+        /* 싫어요 정보를 지워줌 */
+        return redisTemplate.opsForSet().remove(HATE + key.toString(), value.toString());
     }
 
     /* 싫어요, 미선택 -> 좋아요를 눌렀던 시점의 점수 계산 및 기록 저장 */

--- a/src/main/java/com/uplus/ggumi/service/BookDetailService.java
+++ b/src/main/java/com/uplus/ggumi/service/BookDetailService.java
@@ -15,18 +15,17 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class BookDetailService implements BookDetailRepository {
 
-    public static final int TTL = 1;
     private static final String TOTAL_LIKES = "totalLikes:";
     private static final String LIKE = "like:";
     private static final String HATE = "hate:";
     private static final Double LEARNING_RATE = 0.15;
+
     private final RedisTemplate<String, Object> redisTemplate;
 
     private final BookRepository bookRepository;
@@ -76,7 +75,7 @@ public class BookDetailService implements BookDetailRepository {
             return Integer.parseInt(cachedLikes.toString());
         }
 
-        redisTemplate.opsForValue().set(TOTAL_LIKES + bookId, String.valueOf(book.getLikes()), TTL, TimeUnit.HOURS);
+        redisTemplate.opsForValue().set(TOTAL_LIKES + bookId, String.valueOf(book.getLikes()));
 
         return book.getLikes();
     }

--- a/src/main/java/com/uplus/ggumi/service/FeedbackService.java
+++ b/src/main/java/com/uplus/ggumi/service/FeedbackService.java
@@ -24,7 +24,7 @@ public class FeedbackService {
     /* 페이지를 벗어나는 시점 (다른 페이지 이동, 뒤로가기, 새로고침)에 피드백 정보 RDB 영구 저장 */
     public Long saveFeedbackStatus(Long bookId, Long childId) {
 
-        Feedback feedback = feedbackRepository.findByChildId(childId)
+        Feedback feedback = feedbackRepository.findByBookIdAndChildId(bookId, childId)
                 .orElseThrow(() -> new ApiException(ErrorCode.FEEDBACK_NOT_EXIST));
 
         Boolean isLiked = redisTemplate.opsForSet().isMember(LIKE + bookId, childId.toString());

--- a/src/main/java/com/uplus/ggumi/service/ScheduleService.java
+++ b/src/main/java/com/uplus/ggumi/service/ScheduleService.java
@@ -1,0 +1,40 @@
+package com.uplus.ggumi.service;
+
+import com.uplus.ggumi.repository.BookRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private static final String TOTAL_LIKES = "totalLikes:";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final BookRepository bookRepository;
+
+    /* 30분마다 메서드 실행 */
+    @Scheduled(fixedRate = 1800000)
+    public void persistLikesToRDB() {
+        log.info("총 좋아요 데이터 Redis -> MySQL 영구 저장");
+        Set<String> keys = redisTemplate.keys(TOTAL_LIKES + "*");
+
+        if (keys != null && !keys.isEmpty()) {
+            for (String key : keys) {
+                Long bookId = Long.parseLong(key.split(":")[1]);
+                Object cachedLikes = redisTemplate.opsForValue().get(TOTAL_LIKES + bookId);
+
+                if (cachedLikes != null) {
+                    bookRepository.updateLikes(bookId, Integer.parseInt(cachedLikes.toString()));
+                    redisTemplate.delete(TOTAL_LIKES + bookId);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 도서 총 좋아요 개수 증감 로직 개발
1. 좋아요 -> 좋아요 취소, 싫어요
- 좋아요 개수 1 감소해야 하며, 좋아요의 개수가 0 미만으로 떨어지지 않도록 구현
2. 좋아요 취소, 싫어요 -> 좋아요
- 좋아요 개수 1 증가
> 추후에 도서 상세 페이지에 총 좋아요 개수가 뜰수 있도록 프론트 보완 예정
3. 총 좋아요의 개수를 스케쥴링을 통해 30분에 한 번씩 Redis의 총 좋아요 개수들을 RDB로 영구저장

## 자녀 성향 변화에 따른 추천 도서 업데이트 로직 개발
1. 도서 상세 페이지에서 피드백의 변화로 인해 계산 로직이 들어가는 시점에 변화된 자녀의 성향 점수를 기준으로 전체 도서의 점수 차이(절댓값)을 비교해 가장 작은 차이를 가지는 8개의 도서를 추천 도서 테이블에 업데이트 해줌