### PR TITLE
feat(UR-72): 좋아요 순으로 책 정보 가져오기 API 개발(페이징 한 번에 4권씩)

### DIFF
--- a/src/main/java/com/uplus/ggumi/controller/MainController.java
+++ b/src/main/java/com/uplus/ggumi/controller/MainController.java
@@ -22,4 +22,9 @@ public class MainController {
     public ResponseDto<MainBookResponseDto> getBooks(@RequestParam int page, @RequestBody Map<String, Long> request) {
         return ResponseUtil.SUCCESS("책 정보들을 성공적으로 가져왔습니다.", bookService.getBooks(request.get("childId"), page));
     }
+
+    @PostMapping("/popularity")
+    public ResponseDto<MainBookResponseDto> getPopularBooks(@RequestParam int page) {
+            return ResponseUtil.SUCCESS("인기있는 책 리스트",bookService.getPopularBooks(page));
+    }
 }

--- a/src/main/java/com/uplus/ggumi/repository/BookRepository.java
+++ b/src/main/java/com/uplus/ggumi/repository/BookRepository.java
@@ -25,4 +25,8 @@ public interface BookRepository extends JpaRepository<Book, Long> {
 
     @Query("SELECT b FROM Book b ORDER BY b.createdAt DESC ")
     Page<Book> findLatestBooks(Pageable pageable);
+
+    @Query("SELECT b FROM Book b ORDER BY b.likes DESC")
+    Page<Book> findAllByOrderByLikesDesc(Pageable pageable);
+
 }

--- a/src/main/java/com/uplus/ggumi/service/BookService.java
+++ b/src/main/java/com/uplus/ggumi/service/BookService.java
@@ -71,4 +71,24 @@ public class BookService {
                 .size(bookPage.getSize())
                 .build();
     }
+
+    /* 좋아요 수 기준으로 정렬된 리스트 가져오는 메서드*/
+    public MainBookResponseDto getPopularBooks(int page) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+
+        Page<BookDto> bookPage;
+
+        bookPage = bookRepository.findAllByOrderByLikesDesc(pageable)
+                .map(book-> BookDto.builder()
+                        .id(book.getId())
+                        .title(book.getTitle())
+                        .book_image(book.getBook_image())
+                        .build());
+
+        return MainBookResponseDto.builder()
+                .books(bookPage.getContent())
+                .number(bookPage.getNumber())
+                .size(bookPage.getSize())
+                .build();
+    }
 }


### PR DESCRIPTION
좋아요 순으로 책 정보 가져오기 API 개발 (페이징 한 번에 4권씩)

1.  변경 사항 개요

-  MainController 클래스에 코드 추가
    getPopularBooks API 추가: 도서 목록을 좋아요 수 기준으로 정렬하여 페이징 처리된 리스트를 반환하는 기능을 개발했습니다.

- BookService
    `findAllByOrderByLikesDesc` 메서드 추가: 도서의 좋아요 수를 기준으로 정렬하여 데이터를 가져오는 로직을 구현했습니다.
    `getPopularBooks` 메서드 구현: 페이지 단위로 도서 데이터를 좋아요 순으로 가져오고, 이를 
    `MainBookResponseDto` 형식으로 변환하여 반환하는 로직을 추가했습니다.
- Repository
    BookRepository에서 JPQL을 사용하여 도서의 좋아요 수 기준으로 정렬된 목록을 페이징 처리하여 반환하는 쿼리 메서드(`findAllByOrderByLikesDesc`)를 추가했습니다.

3.  개발 사항
- 좋아요 수 기준으로 정렬된 도서 목록을 페이징 처리하여 반환하는 API를 구현했습니다.
- 컨트롤러, 서비스, 레포지토리 레이어에 관련 로직을 추가하였으며, 이를 통해 도서 리스트를 페이지 단위로 관리할 수 있도록 개선했습니다.
4.  테스트
Amazon RDS 연결 문제로 인해 로컬 MySQL 데이터베이스에서 테스트를 진행했습니다.

> 로컬 환경에서 도서 데이터가 잘 조회되고, 페이징 처리 및 좋아요 수 기준으로 정렬된 리스트가 정확히 반환되는지 검증했습니다.

5.  추가 고려 사항
Amazon RDS 복구 후에도 정상 동작하는지 추가 검증이 필요합니다.