### PR TITLE
fix/UR-70: 좋아요 순으로 책정보 가져오는 API 수정

### DIFF
--- a/src/main/java/com/uplus/ggumi/repository/BookRepository.java
+++ b/src/main/java/com/uplus/ggumi/repository/BookRepository.java
@@ -31,6 +31,10 @@ public interface BookRepository extends JpaRepository<Book, Long> {
 
 	Page<Book> findAllByOrderByLikesDesc(Pageable pageable);
 
+	// 좋아요 많은순, 최신 순으로 (limit)개의 도서 정보를 가져오는 메서드
+	@Query(value = "SELECT * FROM book ORDER BY likes DESC, id DESC LIMIT :limit", nativeQuery = true)
+	List<Book> findTopPopularBooks(@Param("limit") int limit);
+
 	@Query("SELECT b FROM Book b WHERE " +
 		"(b.EI BETWEEN :eiMin AND :eiMax) AND " +
 		"(b.FT BETWEEN :ftMin AND :ftMax) AND " +

--- a/src/main/java/com/uplus/ggumi/service/BookService.java
+++ b/src/main/java/com/uplus/ggumi/service/BookService.java
@@ -31,6 +31,7 @@ public class BookService {
 
 	public static final int PAGE_SIZE = 4;
 	public static final int BOOK_MANAGEMENT_PAGE_SIZE = 10;
+	public static final int MAX_POPULAR_BOOKS = 16;
 
 	private final BookRepository bookRepository;
 	private final RecommendRepository recommendRepository;
@@ -85,23 +86,30 @@ public class BookService {
 
 	/* 좋아요 수 기준으로 정렬된 리스트 가져오는 메서드*/
 	public MainBookResponseDto getPopularBooks(int page) {
-		Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
-		Page<BookDto> bookPage;
+		// 인기 도서 정보를 가져옴
+		List<Book> popularBooks = bookRepository.findTopPopularBooks(MAX_POPULAR_BOOKS);
 
-		bookPage = bookRepository.findAllByOrderByLikesDesc(pageable)
+		// 페이지 당 보여줄 도서 수
+		int startIndex = page * PAGE_SIZE;
+		int endIndex = Math.min(startIndex + PAGE_SIZE, popularBooks.size());
+
+		// 페이지에 맞게 도서 목록 생성, Book을 BookDto로 변환
+		List<BookDto> booksOnPage = popularBooks.subList(startIndex, endIndex).stream()
 			.map(book -> BookDto.builder()
 				.id(book.getId())
 				.title(book.getTitle())
 				.book_image(book.getBook_image())
-				.build());
+				.build())
+			.collect(Collectors.toList());
 
 		return MainBookResponseDto.builder()
-			.books(bookPage.getContent())
-			.number(bookPage.getNumber())
-			.size(bookPage.getSize())
-			.totalPages(bookPage.getTotalPages())
+			.books(booksOnPage)
+			.number(page)
+			.size(booksOnPage.size())
+			.totalPages((int)Math.ceil((double)popularBooks.size() / PAGE_SIZE)) // 총 페이지 수 계산
 			.build();
+
 	}
 
 	/** 도서 정보 등록 **/


### PR DESCRIPTION
- 좋아요 순으로 도서 정보 가져올때, 도서 개수를 제한하여 상위 N개만 반환하도록 변경 (현재는 16개로 설정)
- 좋아요 수를 기준으로 내림차순 정렬, 동일한 경우 최신순으로 정렬